### PR TITLE
[Request] Timeout duration

### DIFF
--- a/HttpRequest.cs
+++ b/HttpRequest.cs
@@ -87,6 +87,12 @@ namespace DUCK.Http
 			return headers.Remove(key);
 		}
 
+		public HttpRequest SetTimeout(int duration)
+		{
+			unityWebRequest.timeout = duration;
+			return this;
+		}
+
 		public HttpRequest Send()
 		{
 			foreach (var header in headers)

--- a/HttpResponse.cs
+++ b/HttpResponse.cs
@@ -14,6 +14,7 @@ namespace DUCK.Http
 		public ResponseType ResponseType { get; private set; }
 		public byte[] Bytes { get; private set; }
 		public string Text { get; private set; }
+		public string Error { get; private set; }
 		public Texture Texture { get; private set; }
 		public Dictionary<string, string> ResponseHeaders { get; private set; }
 
@@ -25,6 +26,7 @@ namespace DUCK.Http
 			IsSuccessful = !unityWebRequest.isHttpError && !unityWebRequest.isNetworkError;
 			IsHttpError = unityWebRequest.isHttpError;
 			IsNetworkError = unityWebRequest.isNetworkError;
+			Error = unityWebRequest.error;
 			StatusCode = unityWebRequest.responseCode;
 			ResponseType = HttpUtils.GetResponseType(StatusCode);
 			ResponseHeaders = unityWebRequest.GetResponseHeaders();

--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ All these methods return the HttpRequest instance.
 ##### Progress
 * `OnUploadProgress(Action<float> progress)`  
 * `OnDownloadProgress(Action<float> progress)`  
+##### Configure
+* `SetTimeout(int duration)`
 
 Progress events will invoke each time the progress value has increased, they are subject to Unity's documentation.
 * [Upload Progress Documentation](https://docs.unity3d.com/ScriptReference/Networking.UnityWebRequest-uploadProgress.html)

--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ This has the following properties:
 * `ResponseType ResponseType`  
 * `byte[] Bytes`  
 * `string Text`  
+* `string Error`  
 * `Texture Texture`  
 * `Dictionary<string, string> ResponseHeaders`  
 


### PR DESCRIPTION

 * Allows for setting the timeout duration.
https://docs.unity3d.com/ScriptReference/Networking.UnityWebRequest-timeout.html

* HttpResonse now includes the error string from unityWebRequest.error