### PR TITLE
Http progress event fix

### DIFF
--- a/Scripts/Service/Unity/UnityHttpRequest.cs
+++ b/Scripts/Service/Unity/UnityHttpRequest.cs
@@ -125,7 +125,7 @@ namespace Duck.Http.Service.Unity
 		{
 			if (currentProgress < progress)
 			{
-				currentProgress = progress
+				currentProgress = progress;
 				onProgress?.Invoke(currentProgress);
 			}
 		}

--- a/Scripts/Service/Unity/UnityHttpRequest.cs
+++ b/Scripts/Service/Unity/UnityHttpRequest.cs
@@ -125,7 +125,8 @@ namespace Duck.Http.Service.Unity
 		{
 			if (currentProgress < progress)
 			{
-				onProgress?.Invoke(currentProgress = progress);
+				currentProgress = progress
+				onProgress?.Invoke(currentProgress);
 			}
 		}
 	}

--- a/Scripts/Service/Unity/UnityHttpRequest.cs
+++ b/Scripts/Service/Unity/UnityHttpRequest.cs
@@ -125,8 +125,7 @@ namespace Duck.Http.Service.Unity
 		{
 			if (currentProgress < progress)
 			{
-				currentProgress = progress;
-				onProgress(downloadProgress);
+				onProgress?.Invoke(currentProgress = progress);
 			}
 		}
 	}


### PR DESCRIPTION
* onProgress now uses null propagation before invoking.
* onProgress now invoke with the correct value as a parameter